### PR TITLE
Produce and consume messages forever

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -28,39 +28,37 @@ func NewConsumer(
 	}
 }
 
-func (d *Consumer) Run(ctx context.Context) (retErr error) {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			if err := d.consume(ctx); err != nil {
-				return err
-			}
-		}
-	}
+func (d *Consumer) Run(ctx context.Context, expect int) error {
+	return d.consume(ctx, expect)
 }
 
-func (d *Consumer) consume(ctx context.Context) error {
-	fetches := d.client.PollFetches(ctx)
-	if errs := fetches.Errors(); len(errs) > 0 {
-		return fmt.Errorf("failed to poll fetches: %v", errs)
-	}
-	for _, record := range fetches.Records() {
-		data, err := d.deserializer.Deserialize(record.Topic, record.Value)
-		if err != nil {
-			slog.ErrorContext(ctx, "failed to deserialize record", "error", err)
-			continue
+func (d *Consumer) consume(ctx context.Context, expect int) error {
+	var got int
+	for got < expect {
+		fetches := d.client.PollFetches(ctx)
+		if errs := fetches.Errors(); len(errs) > 0 {
+			return fmt.Errorf("failed to fetch records: %v", errs)
 		}
-		msg, ok := data.(*bufstream_demov1.EmailUpdated)
-		if !ok {
-			slog.ErrorContext(ctx, "received unexpected record type", "type", fmt.Sprintf("%T", msg))
-			continue
+		for _, record := range fetches.Records() {
+			got++
+			data, err := d.deserializer.Deserialize(record.Topic, record.Value)
+			if err != nil {
+				slog.Info(fmt.Sprintf("received malformed message: %v", err))
+				continue
+			}
+			msg, ok := data.(*bufstream_demov1.EmailUpdated)
+			if !ok {
+				slog.Error("received unexpected record type", "type", fmt.Sprintf("%T", msg))
+				continue
+			}
+			var suffix string
+			if old := msg.GetOldAddress(); old == "" {
+				suffix = "redacted old email"
+			} else {
+				suffix = fmt.Sprintf("old email %s", old)
+			}
+			slog.Info(fmt.Sprintf("received message with new email %s and %s", msg.GetNewAddress(), suffix))
 		}
-		slog.InfoContext(ctx, "received record",
-			"old_address", msg.GetOldAddress(),
-			"new_address", msg.GetNewAddress(),
-		)
 	}
 	return nil
 }

--- a/serde.go
+++ b/serde.go
@@ -65,8 +65,7 @@ func (p ProtoSerde[M]) Serialize(_ string, data interface{}) ([]byte, error) {
 }
 
 func (p ProtoSerde[M]) ConfigureDeserializer(_ schemaregistry.Client, _ serde.Type, _ *serde.DeserializerConfig) error {
-	// TODO implement me
-	panic("implement me")
+	panic("unimplemented")
 }
 
 func (p ProtoSerde[M]) Deserialize(_ string, payload []byte) (interface{}, error) {


### PR DESCRIPTION
Rather than producing a few messages, consuming them, then waiting
forever, this PR changes the demo application to alternately produce and
consume messages forever.

It also changes the log output to use printf-style messages. They're not
as good for production observability, but they make the output clearer
to first-time users.
