### PR TITLE
Get non-docker-compose commands working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,38 @@
 BUFSTREAM_VERSION := 0.1.0
 
-.DEFAULT_GOAL := run-docker-compose
+.DEFAULT_GOAL := docker-compose-run
 
 ## Demo run commands
 
-.PHONY: run-docker-compose
-run-docker-compose: # Run the demo within docker compose.
+.PHONY: docker-compose-run
+docker-compose-run: # Run the demo within docker compose.
 	docker compose up --build
 
-.PHONY: run-bufstream
-run-bufstream: # Run Bufstream within Docker.
+.PHONY: docker-bufstream-run
+docker-bufstream-run: # Run Bufstream within Docker.
 	docker run --rm -p "9092:9092" -v "./config/bufstream.yaml:/bufstream.yaml" \
 		us-docker.pkg.dev/buf-images-1/bufstream-public/images/bufstream:$(BUFSTREAM_VERSION) -c "/bufstream.yaml"
 
-.PHONY: run-consume
-run-consume: # Run the demo consumer within Docker.
-	docker build -t bufstream/demo-consume -f Dockerfile.consume .
-	docker run --rm bufstream/demo-consume
-
-.PHONY: run-produce
-run-produce: # Run the demo producer within Docker.
+.PHONY: docker-produce-run
+docker-produce-run: # Run the demo producer within Docker. If you have Go installed, you can call produce-run.
 	docker build -t bufstream/demo-produce -f Dockerfile.produce .
-	docker run --rm bufstream/demo-produce
+	docker run --rm --network=host bufstream/demo-produce
 
-.PHONY: clean-docker-compose
-clean-docker-compose: # Cleanup docker compose assets.
+.PHONY: docker-consume-run
+docker-consume-run: # Run the demo consumer within Docker. If you have Go installed, you can call consume-run.
+	docker build -t bufstream/demo-consume -f Dockerfile.consume .
+	docker run --rm --network=host bufstream/demo-consume
+
+.PHONY: produce-run
+produce-run: # Run the demo producer. Go must be installed
+	go run ./cmd/bufstream-demo-produce
+
+.PHONY: consume-run
+consume-run: # Run the demo consumer. Go must be installed
+	go run ./cmd/bufstream-demo-consume
+
+.PHONY: docker-compose-clean
+docker-compose-clean: # Cleanup docker compose assets.
 	docker compose down --rmi all
 
 ## Development commands

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ docker-compose-run: # Run the demo within docker compose.
 
 .PHONY: docker-bufstream-run
 docker-bufstream-run: # Run Bufstream within Docker.
-	docker run --rm -p "9092:9092" -v "./config/bufstream.yaml:/bufstream.yaml" \
-		us-docker.pkg.dev/buf-images-1/bufstream-public/images/bufstream:$(BUFSTREAM_VERSION) -c "/bufstream.yaml"
+	docker run --rm -p 9092:9092 -v ./config/bufstream.yaml:/bufstream.yaml \
+		"us-docker.pkg.dev/buf-images-1/bufstream-public/images/bufstream:$(BUFSTREAM_VERSION)" \
+			--config /bufstream.yaml
 
 .PHONY: docker-produce-run
 docker-produce-run: # Run the demo producer within Docker. If you have Go installed, you can call produce-run.
@@ -24,11 +25,11 @@ docker-consume-run: # Run the demo consumer within Docker. If you have Go instal
 	docker run --rm --network=host bufstream/demo-consume
 
 .PHONY: produce-run
-produce-run: # Run the demo producer. Go must be installed
+produce-run: # Run the demo producer. Go must be installed.
 	go run ./cmd/bufstream-demo-produce
 
 .PHONY: consume-run
-consume-run: # Run the demo consumer. Go must be installed
+consume-run: # Run the demo consumer. Go must be installed.
 	go run ./cmd/bufstream-demo-consume
 
 .PHONY: docker-compose-clean

--- a/cmd/bufstream-demo-consume/main.go
+++ b/cmd/bufstream-demo-consume/main.go
@@ -47,6 +47,7 @@ func run(ctx context.Context, config app.Config) error {
 		consume.WithMessageHandler(handleEmailUpdated),
 	)
 
+	slog.Info("starting consume")
 	for {
 		// Read as many messages as we can.
 		//

--- a/config/bufstream.yaml
+++ b/config/bufstream.yaml
@@ -7,7 +7,7 @@ kafka:
     host: 0.0.0.0
     port: 9092
   public_address:
-    host: bufstream
+    host: 0.0.0.0
     port: 9092
 observability:
   trace_exporter: NONE

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,10 @@ services:
     # Edit config/bufstream.yaml within this repository to change configuation.
     volumes:
       - "./config/bufstream.yaml:/bufstream.yaml"
-    command: [ "-c", "/bufstream.yaml" ]
+    command: [
+      "--config", "/bufstream.yaml",
+      "--config.kafka.public_address.host", "bufstream",
+    ]
   # The demo consumer.
   #
   # This is a Docker image that just runs the binary created from cmd/bufstream-demo-consume.


### PR DESCRIPTION
As a quick follow-up to #11, this gets the producer and consumer working independent of `docker compose`, both within individual Docker containers, and by just invoking `go run`. This allows for some finer-grained control for those editing the demo to play with it themselves.

This updates `config/bufstream.yaml` to make the public address of Kafka `0.0.0.0:9092` by default, with this overridden via flags within `docker-compose.yaml`. This also:

- Does slight updates to the `make` targets to make them more idiomatic.
- Adds a log statement when the producer and consumer loops start.
- Properly returns from the producer on context cancellation.