### PR TITLE
Fix docker compose health check

### DIFF
--- a/Dockerfile.consume
+++ b/Dockerfile.consume
@@ -3,7 +3,7 @@
 #
 # This allows users to try out this demo without needing to have Go installed, as well
 # as makes the demo runnable within docker compose.
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS builder
 
 ARG TARGETOS TARGETARCH
 ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
@@ -16,11 +16,7 @@ RUN go mod download
 COPY . /app
 RUN go build -ldflags "-s -w" -trimpath -buildvcs=false -o /go/bin/bufstream-demo-consume ./cmd/bufstream-demo-consume
 
-FROM alpine:3.20.3
-
-RUN apk add --update --no-cache \
-    ca-certificates && \
-  rm -rf /var/cache/apk/*
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /go/bin/bufstream-demo-consume /bufstream-demo-consume
 ENTRYPOINT ["/bufstream-demo-consume"]

--- a/Dockerfile.produce
+++ b/Dockerfile.produce
@@ -3,7 +3,7 @@
 #
 # This allows users to try out this demo without needing to have Go installed, as well
 # as makes the demo runnable within docker compose.
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS builder
 
 ARG TARGETOS TARGETARCH
 ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
@@ -16,11 +16,7 @@ RUN go mod download
 COPY . /app
 RUN go build -ldflags "-s -w" -trimpath -buildvcs=false -o /go/bin/bufstream-demo-produce ./cmd/bufstream-demo-produce
 
-FROM alpine:3.20.3
-
-RUN apk add --update --no-cache \
-    ca-certificates && \
-  rm -rf /var/cache/apk/*
+FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /go/bin/bufstream-demo-produce /bufstream-demo-produce
 ENTRYPOINT ["/bufstream-demo-produce"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       # We'll expose bufstream on the host at port 9092.
       - "9092:9092"
     healthcheck:
-      test: nc -z bufstream 9092 || exit -1
+      test: ["CMD", "/usr/local/bin/bufstream", "admin", "status", "--exit-code", "--url", "http://127.0.0.1:9089"]
       start_period: 15s
       interval: 5s
       timeout: 10s


### PR DESCRIPTION
Update docker compose healthcheck for bufstream to call the status CLI instead of using `nc` which isn't available in the distroless image.

Update the docker consumer and producer to use the same distroless nonroot image used by the bufstream container.

Fixes #21.