### PR TITLE
Port over a few internal improvemnts

### DIFF
--- a/cmd/bufstream-demo-produce/main.go
+++ b/cmd/bufstream-demo-produce/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	// See the app package for the boilerplate we use to set up the producer and
 	// consumer, including bound flags.
-	app.Main(run)
+	app.MainAutoCreateTopic(run)
 }
 
 func run(ctx context.Context, config app.Config) error {
@@ -67,7 +67,7 @@ func run(ctx context.Context, config app.Config) error {
 			if errors.Is(err, context.Canceled) {
 				return err
 			}
-			slog.Error("error on produce or semantically valid protobuf message", "error", err)
+			slog.Error("error on produce of semantically valid protobuf message", "error", err)
 		} else {
 			slog.Info("produced semantically valid protobuf message", "id", id)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/pflag v1.0.6
 	github.com/twmb/franz-go v1.18.1
+	github.com/twmb/franz-go/pkg/kadm v1.15.0
 	google.golang.org/protobuf v1.36.5
 )
 
@@ -22,6 +23,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20250224174004-546df14abb99 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/tink-crypto/tink-go/v2 v2.1.0 h1:QXFBguwMwTIaU17EgZpEJWsUSc60b1BAGTzB
 github.com/tink-crypto/tink-go/v2 v2.1.0/go.mod h1:y1TnYFt1i2eZVfx4OGc+C+EMp4CoKWAw2VSEuoicHHI=
 github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
 github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kadm v1.15.0 h1:Yo3NAPfcsx3Gg9/hdhq4vmwO77TqRRkvpUcGWzjworc=
+github.com/twmb/franz-go/pkg/kadm v1.15.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
 github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xiatechs/jsonata-go v1.8.5 h1:m1NaokPKD6LPaTPRl674EQz5mpkJvM3ymjdReDEP6/A=

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -21,8 +21,11 @@ type Config struct {
 	BootstrapServers []string
 	RootCAPath       string
 	Group            string
-	Topic            string
 	ClientID         string
+	Topic            string
+	RecreateTopic    bool
+	TopicConfig      []string
+	TopicPartitions  int
 }
 
 // NewKafkaClient returns a new franz-go Kafka Client for the given Config.
@@ -30,7 +33,6 @@ func NewKafkaClient(config Config, consumer bool) (*kgo.Client, error) {
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(config.BootstrapServers...),
 		kgo.ClientID(config.ClientID),
-		kgo.AllowAutoTopicCreation(),
 	}
 
 	if consumer {


### PR DESCRIPTION
This adds a few improvements that we've had in an internal copy of these demo applications:
1. Don't let consumer auto-create topic.
2. Allow producer to configure the topic when it is created, via new command-line args. This also provides a way to force re-creation of the topic (i.e. delete an existing topic and create a new one with new configuration).
3. Fix a typo in the log message emitted by the producer for publishing a semantically valid message.
