### PR TITLE
Reject messages when schema not resolved

### DIFF
--- a/config/bufstream.yaml
+++ b/config/bufstream.yaml
@@ -13,6 +13,8 @@ data_enforcement:
         coerce: true
         # If a record cannot be parsed, reject all records in the batch.
         on_parse_error: REJECT_BATCH
+        # If a schema cannot be found, reject all records in the batch.
+        on_no_schema: REJECT_BATCH
         # If a record cannot be validated, reject all records in the batch.
         #validation:
           #on_error: REJECT_BATCH


### PR DESCRIPTION
resolves #33 

However, [quickstart](https://buf.build/docs/bufstream/quickstart/) documentation needs to be updated to reflect.

Broker:
```
time=2025-04-13T21:20:45.313Z level=ERROR msg="data enforcement error" kafka.topic.name=email-updated offset=0 error="enforcement decode error, rejecting batch: failed to get schema for ID 1718579042: not found" action=REJECT_BATCH kafka.kafka.api.key=Produce kafka.kafka.api.version=10 kafka.correlation_id=2
```

Producer:
```
time=2025-04-13T21:20:45.178Z level=INFO msg="produced semantically valid protobuf message" id=9f3c9668-b4eb-4810-8cd1-0758ddb4b998
time=2025-04-13T21:20:45.277Z level=INFO msg="produced semantically invalid protobuf message" id=d0933f66-1053-403a-a62f-3ae50c8e403f
time=2025-04-13T21:20:45.313Z level=ERROR msg="error on produce of invalid data" error="failed to produce: INVALID_RECORD: This record has failed the validation on the broker and hence been rejected."
```

Consumer:
```
time=2025-04-13T21:21:57.081Z level=INFO msg="consumed message with new email jadynframi@renner.io and old email diegowisozk@fay.net"
time=2025-04-13T21:21:57.081Z level=INFO msg="consumed message with new email wasp and old email darlenewillms@considine.name"
```
