### PR TITLE
Fixing Bufstream hostname config to use env vars

### DIFF
--- a/config/bufstream.yaml
+++ b/config/bufstream.yaml
@@ -1,9 +1,4 @@
 # yaml-language-server: $schema=schema/buf.bufstream.config.v1alpha1.BufstreamConfig.schema.json
-kafka:
-  address:
-    host: 0.0.0.0
-  public_address:
-    host: bufstream
 data_enforcement:
   schema_registries:
     - name: csr

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,9 @@ services:
     image: bufbuild/bufstream:0.3.20
     hostname: bufstream
     container_name: bufstream
+    environment:
+      BUFSTREAM_KAFKA_HOST: 0.0.0.0
+      BUFSTREAM_KAFKA_PUBLIC_HOST: bufstream
     ports:
       # We'll expose bufstream on the host at port 9092.
       - "9092:9092"


### PR DESCRIPTION
*Problem*

bufstream.yaml is currently setting `kafka.publicaddress` to `bufstream`. The [Bufstream quickstart](https://buf.build/docs/bufstream/quickstart/) directly executes the Bufstream executable, outside of any network where a "bufstream" host would be available. When the reader is in the [Schema enforcement and enveloping](https://buf.build/docs/bufstream/quickstart/#schema-enforcement-and-enveloping) step, this causes the consumer to fail:

```
% go run ./cmd/bufstream-demo-consume \
  --topic email-updated \
  --group email-verifier \
  --csr-url "https://demo.buf.dev/integrations/confluent/bufstream-demo"
time=2025-04-21T14:19:49.869-04:00 level=INFO msg="starting consume"
time=2025-04-21T14:19:50.166-04:00 level=ERROR msg="program error" error="failed to fetch records: [{ 0 unable to join group session: unable to dial: dial tcp: lookup bUfsTreaM: no such host}]"
exit status 1
```

*Solution*

Use the same change @pkwarren used in the Iceberg quickstart: keep Docker-specific config, like hostnames, in `docker-compose.yaml` configuration for environment variables.
