### PR TITLE
Update Bufstream version for Iceberg portion

### DIFF
--- a/iceberg/docker-compose.yaml
+++ b/iceberg/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
       - ./data/iceberg-rest:/iceberg-rest
   # The Bufstream broker. Additional configuration is in bufstream.yaml.
   bufstream:
-    image: bufbuild/bufstream:0.4.5
+    image: bufbuild/bufstream:0.4.7
     container_name: bufstream
     command: [
       "serve",


### PR DESCRIPTION
Due diligence: I've tested e2e tested the quickstart docs page (switching to thise branch after cloning the repo) and every make target. 